### PR TITLE
Signature QC updates

### DIFF
--- a/GeneralTools/NaNstruct.m
+++ b/GeneralTools/NaNstruct.m
@@ -1,0 +1,49 @@
+function S = NaNstruct(S)
+% NaNs out all doubles/vectors in the structure S. 
+% Limited to 3 levels (not recursive). 
+% K. Zeiden 12/26/2023;
+
+for i = 1:length(S)
+    
+    Si = S(i);
+    fields = fieldnames(Si);
+    
+        for ifield = 1:length(fields)
+            if isa(Si.(fields{ifield}),'double')
+                Si.(fields{ifield}) = NaN(size(Si.(fields{ifield})));
+            elseif isa(Si.(fields{ifield}),'struct')
+
+                Si2 = Si.(fields{ifield});
+                fields2 = fieldnames(Si2);
+
+                for ifield2 = 1:length(fields2)
+                    if isa(Si2.(fields2{ifield2}),'double')
+                        Si2.(fields2{ifield2}) = NaN(size(Si2.(fields2{ifield2})));
+                    elseif isa(Si2.(fields2{ifield2}),'struct')
+
+                        Si3 = Si2.(fields2{ifield2});
+                        fields3 = fieldnames(Si3);
+                        
+                        for ifield3 = 1:length(fields3)
+                            if isa(Si3.(fields3{ifield3}),'double')
+                                Si3.(fields3{ifield3}) = NaN(size(Si3.(fields3{ifield3})));
+                            elseif isa(Si3.(fields3{ifield3}),'struct')
+                                warning('Structure 3+ levels deep')
+                            end
+                        end
+
+                        Si2.(fields2{ifield2}) = Si3;
+                    end
+                end
+                Si.(fields{ifield}) = Si2;
+             end
+        end
+    
+    S(i) = Si;
+    
+end
+
+
+% End function
+end
+

--- a/GeneralTools/NaNstructR.m
+++ b/GeneralTools/NaNstructR.m
@@ -1,0 +1,30 @@
+function S = NaNstructR(S)
+% Recursive version of NaNstruct
+% K. Zeiden 12/26/2023
+
+for i = 1:length(S)
+    
+    Si = S(i);
+    fields = fieldnames(Si);
+    
+        for ifield = 1:length(fields)
+            
+            var = Si.(fields{ifield});
+            
+            if isa(var,'numeric')
+                Si.(fields{ifield}) = NaN(size(var));
+                
+            elseif isa(var,'struct')
+                 Si.(fields{ifield}) = NaNstructR(var);
+                 
+             end
+        end
+    
+    S(i) = Si;
+    
+end
+
+
+% End function
+end
+

--- a/Signature/batch_readSIG.m
+++ b/Signature/batch_readSIG.m
@@ -16,7 +16,7 @@ if ~strcmp(expdir(end),slash)
     expdir = [expdir slash];
 end
 
-for im = 2:length(missions)
+for im = 1:length(missions)
     
     bfiles = dir([expdir missions(im).name slash 'SIG' slash 'Raw' slash '*' slash '*.dat']);
 

--- a/Signature/batch_readSIG.m
+++ b/Signature/batch_readSIG.m
@@ -1,0 +1,40 @@
+% Bulk conversion of raw Signature 1000 files to mat files
+% Counts on folder structure with following format:
+%       expdir\mission\SIG\Raw\YYYYMMDD\rawfile.dat
+
+% Experiment to process
+expdir = 'S:\NORSE\2023\';
+missions = dir([expdir 'SWIFT2*']);
+
+%% Run through each mission
+if ispc
+    slash = '\';
+else
+    slash = '/';
+end
+if ~strcmp(expdir(end),slash)
+    expdir = [expdir slash];
+end
+
+for im = 2:length(missions)
+    
+    bfiles = dir([expdir missions(im).name slash 'SIG' slash 'Raw' slash '*' slash '*.dat']);
+
+    for iburst = 1:length(bfiles)
+
+        disp(['Burst ' num2str(iburst) ' : ' bfiles(iburst).name(1:end-4)])
+
+        % Read burst file (skip if mat file already exists)
+        if exist([bfiles(iburst).folder slash bfiles(iburst).name(1:end-4) '.mat'],'file')
+            disp('*** mat file already exists ***')
+            continue
+        else
+        [burst,avg,battery,echo] = readSWIFTv4_SIG([bfiles(iburst).folder slash bfiles(iburst).name]);
+            if isempty(avg)
+                disp('*** no data ***')
+            end
+        end
+
+    end
+    
+end

--- a/Signature/catSIG.m
+++ b/Signature/catSIG.m
@@ -42,7 +42,6 @@ if isfield(SIG,'time')
     sig.N = sig.hrcorr;
     sig.pitchvar = NaN(1,length(sig.time));
     sig.rollvar = NaN(1,length(sig.time));
-    sig.waveheight = NaN(1,length(sig.time));
     sig.hrwmag = sig.hrcorr;
     sig.hrwmag0 = sig.hrcorr;
     sig.hrw0 = sig.hrcorr;
@@ -75,7 +74,6 @@ if isfield(SIG,'time')
         sig.N(1:nz,it) = SIG(it).HRprofile.QC.NEOF;
         sig.pitchvar(it) = SIG(it).motion.pitchvar;
         sig.rollvar(it) = SIG(it).motion.rollvar;
-        sig.waveheight(it) = SIG(it).motion.waveheight;
         sig.hrwmag(1:nz,it) = SIG(it).HRprofile.QC.wmag;
         sig.hrwmag0(1:nz,it) = SIG(it).HRprofile.QC.wmag0;
         sig.hrw0(1:nz,it) = SIG(it).HRprofile.QC.w0;
@@ -108,7 +106,6 @@ if isfield(SIG,'time')
         sig.N(:,badburst) = [];
         sig.pitchvar(badburst) = [];
         sig.rollvar(badburst) = [];
-        sig.waveheight(badburst) = [];
         sig.hrw0(:,badburst) = [];
         sig.hrwvar0(:,badburst) = [];
         sig.hrwmag(:,badburst) = [];

--- a/Signature/processSIGavg.m
+++ b/Signature/processSIGavg.m
@@ -1,53 +1,52 @@
 function [profile,fh] = processSIGavg(avg,opt)
 
     % Data
-    avgtime = avg.time;
-    avgamp = avg.AmplitudeData;
-    avgcorr = avg.CorrelationData;
-    avgvel = avg.VelocityData;
-    avgz = opt.xz + avg.Blanking + avg.CellSize*(1:size(avg.VelocityData,2));
-    avgtemp = filloutliers(avg.Temperature,'linear');
+    time = avg.time;
+    amp = avg.AmplitudeData;
+    corr = avg.CorrelationData;
+    vel = avg.VelocityData;
+    z = opt.xz + avg.Blanking + avg.CellSize*(1:size(avg.VelocityData,2));
+    temp = filloutliers(avg.Temperature,'linear');
 
     % Raw velocity profiles & standard error
-    nping = length(avgtime);
-    nbin = length(avgz);
-    avgu_noqc = squeeze(nanmean(avgvel,1));
-    avguerr_noqc = squeeze(nanstd(avgvel,[],1))/sqrt(nping);
+    nping = length(time);
+    nbin = length(z);
+    avgu_noqc = squeeze(nanmean(vel,1));
+    avguerr_noqc = squeeze(nanstd(vel,[],1))/sqrt(nping);
 
     % QC: flag corr minimum values
-    lowcorr = avgcorr < opt.mincorr;
+    lowcorr = corr < opt.mincorr;
     badbin = squeeze(nansum(lowcorr,1)./nping > opt.pbadmax/100); %#ok<*NANSUM>
     badbin = permute(repmat(badbin,1,1,nping),[3 1 2]);
     badping = squeeze(sum(lowcorr,2)./nbin > opt.pbadmax/100);
     badping = permute(repmat(badping,1,1,nbin),[1 3 2]);
 
     % QC: flag fish w/ anomalously high amplitude: look for heavily skewed distributions
-    badfish = false(size(avgamp));
+    badfish = false(size(amp));
     for ibeam = 1:4
         for ibin = 1:nbin
-            [a,b] = hist(squeeze(avgamp(:,ibin,ibeam)));
+            [a,b] = hist(squeeze(amp(:,ibin,ibeam)));
             if sum(a) == 0
                 continue
             end
             [~,j] = max(a);
             if j == 1
                 ampfloor = b(1)+5;
-                badfish(:,ibin,ibeam) = avgamp(:,ibin) > ampfloor;
+                badfish(:,ibin,ibeam) = amp(:,ibin) > ampfloor;
             end
         end
     end
 
     % QC broadband data and recompute velocity profiles & SE
-    iQC = false(size(avgvel));
+    iQC = false(size(vel));
     if opt.QCcorr; iQC(lowcorr) = true; end%#ok<*UNRCH>
     if opt.QCbin; iQC(badbin) = true; end
     if opt.QCping; iQC(badping) = true; end
     if opt.QCfish; iQC(badfish) = true; end
-    velqc = avgvel;
+    velqc = vel;
     velqc(iQC) = NaN;
-    navg = squeeze(sum(~iQC,1));
-    avgu = squeeze(nanmean(velqc,1));
-    avguvar = squeeze(var(velqc,[],1,'omitnan'));
+    u = squeeze(nanmean(velqc,1));
+    uvar = squeeze(var(velqc,[],1,'omitnan'));
 
     % Plot beam data and QC flags
     if opt.plotburst
@@ -61,18 +60,18 @@ function [profile,fh] = processSIGavg(avg,opt)
         set(gcf,'outerposition',MP(1,:).*[1 1 1 1]);
         for ibeam = 1:4
             subplot(5,4,ibeam+0*4)
-            imagesc(squeeze(avgamp(:,:,ibeam))')
+            imagesc(squeeze(amp(:,:,ibeam))')
             caxis([50 160]); cmocean('amp')
             title(['Beam ' num2str(ibeam)]);
             if ibeam == 1; ylabel('Bin #'); end
             if ibeam == 4;pos = get(gca,'Position');c(1) = colorbar;set(gca,'Position',pos);end
             subplot(5,4,ibeam+1*4)
-            imagesc(squeeze(avgcorr(:,:,ibeam))')
+            imagesc(squeeze(corr(:,:,ibeam))')
             caxis([opt.mincorr-5 100]);  cmocean('amp')
             if ibeam == 1; ylabel('Bin #'); end
             if ibeam == 4;pos = get(gca,'Position');c(2) = colorbar;set(gca,'Position',pos);end
             subplot(5,4,ibeam+2*4)
-            imagesc(squeeze(avgvel(:,:,ibeam))')
+            imagesc(squeeze(vel(:,:,ibeam))')
             caxis([-0.5 0.5]);cmocean('balance');
             if ibeam == 1; ylabel('Bin #'); end
             if ibeam == 4;pos = get(gca,'Position');c(3) = colorbar;set(gca,'Position',pos);end
@@ -84,7 +83,7 @@ function [profile,fh] = processSIGavg(avg,opt)
             subplot(5,4,ibeam+4*4)
             bincolor = jet(nbin);
             for ibin = 1:nbin
-            vbin = squeeze(avgvel(:,ibin,ibeam));
+            vbin = squeeze(vel(:,ibin,ibeam));
              [PS,F,~] = hannwinPSD2(vbin,90,1,'par');
             loglog(F,PS,'color',bincolor(ibin,:))
             hold on
@@ -108,11 +107,11 @@ function [profile,fh] = processSIGavg(avg,opt)
         clear b1 b2 b3 p1 p2 p3
         for ibeam = 1:4
             subplot(2,3,ibeam)
-            errorbar(-avgz,avgu_noqc(:,ibeam),avguerr_noqc(:,ibeam));
+            errorbar(-z,avgu_noqc(:,ibeam),avguerr_noqc(:,ibeam));
             hold on
-            errorbar(-avgz,avgu(:,ibeam),avguvar(:,ibeam));
+            errorbar(-z,u(:,ibeam),uvar(:,ibeam));
             grid
-            xlim([min(-avgz) max(-avgz)])
+            xlim([min(-z) max(-z)])
             ylim(nanmean(avgu_noqc(:,ibeam))+[-0.1 0.1])
             plot(xlim,[0 0],'--k')
             view(gca,[90 -90])
@@ -120,9 +119,9 @@ function [profile,fh] = processSIGavg(avg,opt)
             ylabel('u_{r} [m/s]');xlabel('z[m]')
         end
         subplot(2,3,5)
-        p1 = plot(squeeze(nanmean(avgamp)),-avgz,'linewidth',1.5);
+        p1 = plot(squeeze(nanmean(amp)),-z,'linewidth',1.5);
         hold on
-        ylim([min(-avgz) max(-avgz)])
+        ylim([min(-z) max(-z)])
         xlim([50 175])
         hold on
         legend(p1,'Beam 1','Beam 2','Beam 3','Beam 4',...
@@ -131,9 +130,9 @@ function [profile,fh] = processSIGavg(avg,opt)
         ylabel('z [m]')
         title('Amplitude')
         subplot(2,3,6)
-        plot(squeeze(nanmean(avgcorr)),-avgz,'linewidth',1.5);
+        plot(squeeze(nanmean(corr)),-z,'linewidth',1.5);
         hold on
-        ylim([min(-avgz) max(-avgz)])
+        ylim([min(-z) max(-z)])
         xlim([40 100])
         plot(opt.mincorr*[1 1],ylim,'r');
         title('Correlation')
@@ -145,29 +144,28 @@ function [profile,fh] = processSIGavg(avg,opt)
     end
 
     % Check that QC actually reduced the standard error
-    if any(avguvar(:) > avguerr_noqc(:))
-        ibadqc = avguvar > avguerr_noqc;
-        avgu(ibadqc) = avgu_noqc(ibadqc);
-        avguvar(ibadqc) = avguerr_noqc(ibadqc);
+    if any(uvar(:) > avguerr_noqc(:))
+        ibadqc = uvar > avguerr_noqc;
+        u(ibadqc) = avgu_noqc(ibadqc);
+        uvar(ibadqc) = avguerr_noqc(ibadqc);
     end
 
     % Separate U, V, W
-    profile.avgz = avgz;
-    profile.avgw = avgu(:,4);
-    profile.avgv = avgu(:,2);
-    profile.avgu = avgu(:,1);
-    % Save variance, corr & amp profiles for QC later if necessary
-    profile.avgwvar = avguvar(:,4);
-    profile.avgvvar = avguvar(:,2);
-    profile.avguvar = avguvar(:,1);
-    profile.ucorr = squeeze(mean(avgcorr(:,:,1)));
-    profile.vcorr = squeeze(mean(avgcorr(:,:,2)));
-    profile.wcorr = squeeze(mean(avgcorr(:,:,4)));
-    profile.uamp = squeeze(mean(avgamp(:,:,1)));
-    profile.vamp = squeeze(mean(avgamp(:,:,2)));
-    profile.wamp = squeeze(mean(avgamp(:,:,4)));
-    profile.temp = avgtemp;
-    profile.temp = mean(profile.temp(1:round(end/4)),'omitnan');
+    profile.z = z;
+    profile.w = u(:,4);
+    profile.v = u(:,2);
+    profile.u = u(:,1);
+    profile.wvar = uvar(:,4);
+    profile.vvar = uvar(:,2);
+    profile.uvar = uvar(:,1);
+    profile.temp = mean(temp(1:round(end/4)),'omitnan');
+    % QC
+    profile.QC.ucorr = squeeze(mean(corr(:,:,1)));
+    profile.QC.vcorr = squeeze(mean(corr(:,:,2)));
+    profile.QC.wcorr = squeeze(mean(corr(:,:,4)));
+    profile.QC.uamp = squeeze(mean(amp(:,:,1)));
+    profile.QC.vamp = squeeze(mean(amp(:,:,2)));
+    profile.QC.wamp = squeeze(mean(amp(:,:,4)));
     
 end
 

--- a/Signature/processSIGburst.m
+++ b/Signature/processSIGburst.m
@@ -6,7 +6,9 @@ function [HRprofile,fh] = processSIGburst(burst,opt)
     % Check to make sure dimensions correct
     if length(size(burst.VelocityData)) > 2
         disp('   HR data dimensions bad')
-        badburst = true;
+        HRprofile = [];
+        fh = [];
+        return
     end
     
     % Data
@@ -121,15 +123,15 @@ function [HRprofile,fh] = processSIGburst(burst,opt)
         HRprofile.eps_struct0 = NaN(size(hrw))';
         HRprofile.eps_structHP = NaN(size(hrw))';
         HRprofile.eps_structEOF = NaN(size(hrw))';
-        HRprofile.QC.wmag = NaN(size(hrw));
-        HRprofile.QC.wmag0 = NaN(size(hrw));
-        HRprofile.QC.w0 = NaN(size(hrw));
-        HRprofile.QC.wvar0 = NaN(size(hrw));
+        HRprofile.QC.wmag = mean(abs(wclean),2,'omitnan')';
+        HRprofile.QC.wmag0 = mean(abs(hrvel),2,'omitnan')';
+        HRprofile.QC.w0 = mean(hrvel,2,'omitnan')';
+        HRprofile.QC.wvar0 = var(hrvel,[],2,'omitnan')';
         HRprofile.QC.wpvar = NaN(size(hrw));
-        HRprofile.QC.hrcorr = NaN(size(hrw));
-        HRprofile.QC.hramp = NaN(size(hrw));
-        HRprofile.QC.hrampvar = NaN(size(hrw));
-        HRprofile.QC.hrcorrvar = NaN(size(hrw));
+        HRprofile.QC.hrcorr = mean(hrcorr,2,'omitnan')';
+        HRprofile.QC.hramp = mean(hramp,2,'omitnan')';
+        HRprofile.QC.hrampvar = var(hramp,[],2,'omitnan')';
+        HRprofile.QC.hrcorrvar = var(hrcorr,[],2,'omitnan')';
         HRprofile.QC.mspe0 = NaN(size(hrw));
         HRprofile.QC.mspeHP = NaN(size(hrw));
         HRprofile.QC.mspeEOF = NaN(size(hrw));
@@ -142,7 +144,7 @@ function [HRprofile,fh] = processSIGburst(burst,opt)
         HRprofile.QC.N0 = NaN(size(hrw));
         HRprofile.QC.NHP = NaN(size(hrw));
         HRprofile.QC.NEOF = NaN(size(hrw));    
-        HRprofile.QC.pspike = NaN(size(hrw));
+        HRprofile.QC.pspike = (sum(ispike,2,'omitnan')./nping)';
     end
 
     % Plot Burst 

--- a/Signature/processSIGburst.m
+++ b/Signature/processSIGburst.m
@@ -65,15 +65,16 @@ function [HRprofile,fh] = processSIGburst(burst,opt)
     wpeof = eofs(:,opt.nsumeof+1:end)*(eof_amp(:,opt.nsumeof+1:end)');
     
     %Structure Function Dissipation
+    ibad = ispike | repmat(badping,nbin,1);
     rmin = dz;
     rmax = 4*dz;
     nzfit = 1;
     w = wclean;
     wp1 = wpeof;
     wp2 = wphp;
-    w(ispike) = NaN;
-    wp1(ispike) = NaN;
-    wp2(ispike) = NaN;
+    w(ibad) = NaN;
+    wp1(ibad) = NaN;
+    wp2(ibad) = NaN;
     warning('off','all')
     [eps_struct0,qual0] = SFdissipation(w,hrz,rmin,2*rmax,nzfit,'cubic','mean');
     [eps_structEOF,qualEOF] = SFdissipation(wp1,hrz,rmin,rmax,nzfit,'linear','mean');

--- a/Signature/processSIGburst.m
+++ b/Signature/processSIGburst.m
@@ -58,7 +58,7 @@ function [HRprofile,fh] = processSIGburst(burst,opt)
     % 2) EOF High-pass (remove worst pings to get good EOFs)
     badping = sum(ispike)./nbin > 0.6; % | std(wphp,[],'omitnan') > 0.01;
     eof_amp = NaN(nping,nbin);
-    [eofs,eof_amp(~badping,:),eofvar,~] = eof(wclean(:,~badping)');
+    [eofs,eof_amp(~badping,:),~,~] = eof(wclean(:,~badping)');
     for ieof = 1:nbin
         eof_amp(:,ieof) = interp1(find(~badping),eof_amp(~badping,ieof),1:nping);
     end

--- a/Signature/processSIGburst.m
+++ b/Signature/processSIGburst.m
@@ -1,6 +1,225 @@
-function HRprofile = processSIGburst(burst)
-%UNTITLED6 Summary of this function goes here
-%   Detailed explanation goes here
+function [HRprofile,fh] = processSIGburst(burst,opt)
 
+    % Initialize bad burst flag
+    badburst = false;
+
+    % Check to make sure dimensions correct
+    % NOTE: need tocatch error in reprocess_SIG
+    if length(size(burst.VelocityData)) > 2
+        disp('   HR data dimensions bad')
+        badburst = true;
+    end
+    
+    % Data
+    hrtime = burst.time;
+    hrcorr = burst.CorrelationData';
+    hramp = burst.AmplitudeData';
+    hrvel = -burst.VelocityData';
+
+    % N pings + N z-bins
+    [nbin,nping] = size(hrvel);
+    dz = burst.CellSize;
+    bz = burst.Blanking;
+    hrz = opt.xz + bz + dz*(1:nbin);
+    dt = ( max(hrtime) - min(hrtime) ) ./nping*24*3600; %range(hrtime)./nping*24*3600;
+
+    % Find Spikes (phase-shift threshold, Shcherbina 2018)
+    L = bz+dz*nbin; % m
+    F0 = 10^6; % Hz, pulse carrier frequency (1 MHz for Sig 1000)
+    cs = mean(burst.SoundSpeed,'omitnan'); % m/s
+    Vr = cs.^2./(4*F0*L);% m/s
+    nfilt = round(1/dz);% 1 m
+    [wclean,ispike] = despikeSIG(hrvel,nfilt,Vr/2,'interp');
+    
+    %%%%%% Abort if spikes > 70% of the data (arbitrary, sigh) %%%%%%
+    if sum(ispike(:))/numel(hrvel) > 0.7
+        disp('   HR data spike percentage > 70%')
+        badburst = true;
+    end
+    
+    %%%%%% Velocity Profile %%%%%%%%
+    hrw = nanmean(wclean,2);
+    hrwvar = var(wclean,[],2,'omitnan');
+
+    %%%%%% Dissipation Estimates %%%%%%
+    
+    if ~badburst
+
+    % Sampling rate and window size
+    fs = 1/dt; nwin = 64;
+    if nwin > nping
+    nwin = nping;
+    end
+    
+    % 1) Spatial High-pass
+    nsm = round(2/dz); % 1 m
+    wphp = wclean - smooth_mat(wclean',hann(nsm))';
+
+    % 2) EOF High-pass (remove worst pings to get good EOFs)
+    badping = sum(ispike)./nbin > 0.6; % | std(wphp,[],'omitnan') > 0.01;
+    eof_amp = NaN(nping,nbin);
+    [eofs,eof_amp(~badping,:),eofvar,~] = eof(wclean(:,~badping)');
+    for ieof = 1:nbin
+        eof_amp(:,ieof) = interp1(find(~badping),eof_amp(~badping,ieof),1:nping);
+    end
+    wpeof = eofs(:,opt.nsumeof+1:end)*(eof_amp(:,opt.nsumeof+1:end)');
+    
+    %Structure Function Dissipation
+    rmin = dz;
+    rmax = 4*dz;
+    nzfit = 1;
+    w = wclean;
+    wp1 = wpeof;
+    wp2 = wphp;
+    w(ispike) = NaN;
+    wp1(ispike) = NaN;
+    wp2(ispike) = NaN;
+    warning('off','all')
+    [eps_struct0,qual0] = SFdissipation(w,hrz,rmin,2*rmax,nzfit,'cubic','mean');
+    [eps_structEOF,qualEOF] = SFdissipation(wp1,hrz,rmin,rmax,nzfit,'linear','mean');
+    [eps_structHP,qualHP] = SFdissipation(wp2,hrz,rmin,rmax,nzfit,'linear','mean');
+    warning('on','all')
+
+    % Save results to struture
+    HRprofile.w = hrw;
+    HRprofile.wvar = hrwvar;
+    HRprofile.z = hrz';
+    HRprofile.eps_struct0 = eps_struct0';
+    HRprofile.eps_structHP = eps_structHP';
+    HRprofile.eps_structEOF = eps_structEOF';
+    
+    % Save QC params to structure    
+    HRprofile.QC.wmag = mean(abs(wclean),2,'omitnan')';
+    HRprofile.QC.wmag0 = mean(abs(hrvel),2,'omitnan')';
+    HRprofile.QC.w0 = mean(hrvel,2,'omitnan')';
+    HRprofile.QC.wvar0 = var(hrvel,[],2,'omitnan')';
+    HRprofile.QC.wpvar = var(wpeof,[],2,'omitnan')';
+    HRprofile.QC.hrcorr = mean(hrcorr,2,'omitnan')';
+    HRprofile.QC.hramp = mean(hramp,2,'omitnan')';
+    HRprofile.QC.hrampvar = var(hramp,[],2,'omitnan')';
+    HRprofile.QC.hrcorrvar = var(hrcorr,[],2,'omitnan')';
+    HRprofile.QC.mspe0 = qual0.mspe;
+    HRprofile.QC.mspeHP = qualHP.mspe;
+    HRprofile.QC.mspeEOF = qualEOF.mspe;
+    HRprofile.QC.slope0 = qual0.slope;
+    HRprofile.QC.slopeHP = qualHP.slope;
+    HRprofile.QC.slopeEOF = qualEOF.slope;
+    HRprofile.QC.epserr0 = qual0.epserr;
+    HRprofile.QC.epserrHP = qualHP.epserr;
+    HRprofile.QC.epserrEOF = qualEOF.epserr;       
+    HRprofile.QC.N0 = qual0.N;
+    HRprofile.QC.NHP = qualHP.N;
+    HRprofile.QC.NEOF = qualEOF.N;    
+    HRprofile.QC.pspike = (sum(ispike,2,'omitnan')./nping)';
+    
+    else
+        disp('   Bad burst, skipping dissipation...')
+        % Bad burst, save NaNs to struture
+        HRprofile.w = hrw;
+        HRprofile.wvar = hrwvar;
+        HRprofile.z = hrz';
+        HRprofile.eps_struct0 = NaN(size(hrw))';
+        HRprofile.eps_structHP = NaN(size(hrw))';
+        HRprofile.eps_structEOF = NaN(size(hrw))';
+        HRprofile.QC.wmag = NaN(size(hrw));
+        HRprofile.QC.wmag0 = NaN(size(hrw));
+        HRprofile.QC.w0 = NaN(size(hrw));
+        HRprofile.QC.wvar0 = NaN(size(hrw));
+        HRprofile.QC.wpvar = NaN(size(hrw));
+        HRprofile.QC.hrcorr = NaN(size(hrw));
+        HRprofile.QC.hramp = NaN(size(hrw));
+        HRprofile.QC.hrampvar = NaN(size(hrw));
+        HRprofile.QC.hrcorrvar = NaN(size(hrw));
+        HRprofile.QC.mspe0 = NaN(size(hrw));
+        HRprofile.QC.mspeHP = NaN(size(hrw));
+        HRprofile.QC.mspeEOF = NaN(size(hrw));
+        HRprofile.QC.slope0 = NaN(size(hrw));
+        HRprofile.QC.slopeHP = NaN(size(hrw));
+        HRprofile.QC.slopeEOF = NaN(size(hrw));
+        HRprofile.QC.epserr0 = NaN(size(hrw));
+        HRprofile.QC.epserrHP = NaN(size(hrw));
+        HRprofile.QC.epserrEOF = NaN(size(hrw));       
+        HRprofile.QC.N0 = NaN(size(hrw));
+        HRprofile.QC.NHP = NaN(size(hrw));
+        HRprofile.QC.NEOF = NaN(size(hrw));    
+        HRprofile.QC.pspike = NaN(size(hrw));
+    end
+
+    % Plot Burst 
+    if opt.plotburst
+        
+        % Visualize Data
+        fh(1) = figure('color','w');
+        clear c
+        MP = get(0,'monitorposition');
+        set(gcf,'outerposition',MP(1,:).*[1 1 1 1]);
+        subplot(4,1,1)
+        imagesc(hramp)
+        caxis([50 160]); cmocean('amp')
+        title('HR Data');
+        ylabel('Bin #')
+        c = colorbar;c.Label.String = 'A (dB)';
+        subplot(4,1,2)
+        imagesc(hrcorr)
+        caxis([35 100]);cmocean('amp')
+        ylabel('Bin #')
+        c = colorbar;c.Label.String = 'C (%)';
+        subplot(4,1,3)
+        imagesc(hrvel)
+        caxis([-0.5 0.5]);cmocean('balance');
+        ylabel('Bin #')
+        c = colorbar;c.Label.String = 'U_r(m/s)';
+        subplot(4,1,4)
+        imagesc(ispike)
+        caxis([0 2]);colormap(gca,[rgb('white'); rgb('black')])
+        ylabel('Bin #')
+        c = colorbar;c.Ticks = [0.5 1.5];
+        c.TickLabels = {'Good','Spike'};
+        xlabel('Ping #')
+        drawnow
+        if opt.saveplots
+            figname = [savedir SNprocess slash get(gcf,'Name')];
+            print(figname,'-dpng')
+            close gcf
+        end
+
+        % Velocity and Dissipation Profiles
+        fh(2) = figure('color','w');
+        clear b s
+        MP = get(0,'monitorposition');
+        set(gcf,'outerposition',MP(1,:).*[1 1 0.5 1]);
+        subplot(1,2,1)
+        b(1) = errorbar(hrw,hrz,sqrt(hrwvar)./nping,'horizontal');
+        hold on
+        set(b,'LineWidth',2)
+        plot([0 0],[0 20],'k--')
+        xlabel('w [m/s]');
+        title('Velocity')
+        set(gca,'Ydir','reverse')
+        ylim([0 6])
+        xlim([-0.075 0.075])
+        set(gca,'YAxisLocation','right')
+        subplot(1,2,2)
+        s(1) = semilogx(eps_structEOF,hrz,'r','LineWidth',2);
+        hold on
+        s(2) =  semilogx(eps_structHP,hrz,':r','LineWidth',2);
+        s(3) = semilogx(eps_struct0,hrz,'color',rgb('grey'),'LineWidth',2);
+        xlim(10.^([-9 -3]))
+        ylim([0 6])
+        legend(s,'SF','SF (high-pass)','SF (modified)','Location','southeast')
+        title('Dissipation')
+        xlabel('\epsilon [W/Kg]'),ylabel('z [m]')
+        set(gca,'Ydir','reverse')
+        set(gca,'YAxisLocation','right')
+        drawnow
+        if opt.saveplots
+            figname = [savedir SNprocess slash get(gcf,'Name')];
+            print(figname,'-dpng')
+            close gcf
+        end
+    else
+        fh = [];
+    end
+                   
 end
 

--- a/Signature/processSIGburst.m
+++ b/Signature/processSIGburst.m
@@ -4,7 +4,6 @@ function [HRprofile,fh] = processSIGburst(burst,opt)
     badburst = false;
 
     % Check to make sure dimensions correct
-    % NOTE: need tocatch error in reprocess_SIG
     if length(size(burst.VelocityData)) > 2
         disp('   HR data dimensions bad')
         badburst = true;

--- a/Signature/reprocess_SIG.m
+++ b/Signature/reprocess_SIG.m
@@ -281,7 +281,7 @@ for iburst = 1:nburst
 
     badburst = smallfile | outofwater | badamp | badcorr | badvel;
 
-%     %%%%%%% Process Broadband velocity data ('avg' structure) %%%%%%
+    %%%%%%% Process Broadband velocity data ('avg' structure) %%%%%%
 
       [profile,fh] = processSIGavg(avg,opt);
       
@@ -302,267 +302,32 @@ for iburst = 1:nburst
 
     %%%%%%% Process HR velocity data ('burst' structure) %%%%%%
     
-    if length(size(burst.VelocityData)) > 2
-        badburst = 1;
-        disp('Bad HR Data...')
-        hrw = NaN(size(SIG(end).HRprofile.w));
-        hrwvar = NaN(size(SIG(end).HRprofile.w));
-        hrz = SIG(end).HRprofile.z;
-        eps_struct0 = NaN(size(SIG(end).HRprofile.eps_struct0));
-        eps_structHP = NaN(size(SIG(end).HRprofile.eps_struct0));
-        eps_structEOF = NaN(size(SIG(end).HRprofile.eps_struct0));
-    else
-
-        % HR Data
-        hrtime = burst.time;
-        hrcorr = burst.CorrelationData';
-        hramp = burst.AmplitudeData';
-        hrvel = -burst.VelocityData';
-
-        % N pings + N z-bins
-        [nbin,nping] = size(hrvel);
-        dz = burst.CellSize;
-        bz = burst.Blanking;
-        hrz = opt.xz + bz + dz*(1:nbin);
-        dt = ( max(hrtime) - min(hrtime) ) ./nping*24*3600; %range(hrtime)./nping*24*3600;
-
-        % QC: Find spikes w/phase-shift threshold (Shcherbina 2018)
-        L = bz+dz*nbin; % m
-        F0 = 10^6; % Hz, pulse carrier frequency (1 MHz for Sig 1000)
-        cs = mean(burst.SoundSpeed,'omitnan'); % m/s
-        Vr = cs.^2./(4*F0*L);% m/s
-        nfilt = round(1/dz);% 1 m
-        [wclean,ispike] = despikeSIG(hrvel,nfilt,Vr/2,'interp');
-
-        % Spatial High-pass and flag bad pings w/too high variance
-        nsm = round(2/dz); % 1 m
-        wphp = wclean - smooth_mat(wclean',hann(nsm))';
-        badping = sum(ispike)./nbin > 0.5 | std(wphp,[],'omitnan') > 0.01;
-
-        % QC & Calculate Mean Velocity + SE
-        hrw = nanmean(wclean,2);
-        hrwvar = var(wclean,[],2,'omitnan');
-
-        % Plot beam data and QC info
-        if opt.plotburst
-            clear c
-            figure('color','w','Name',[bname '_hr_data'])
-            MP = get(0,'monitorposition');
-            set(gcf,'outerposition',MP(1,:).*[1 1 1 1]);
-            subplot(4,1,1)
-            imagesc(hramp)
-            caxis([50 160]); cmocean('amp')
-            title('HR Data');
-            ylabel('Bin #')
-            c = colorbar;c.Label.String = 'A (dB)';
-            subplot(4,1,2)
-            imagesc(hrcorr)
-            caxis([opt.mincorr-5 100]);cmocean('amp')
-            ylabel('Bin #')
-            c = colorbar;c.Label.String = 'C (%)';
-            subplot(4,1,3)
-            imagesc(hrvel)
-            caxis([-0.5 0.5]);cmocean('balance');
-            ylabel('Bin #')
-            c = colorbar;c.Label.String = 'U_r(m/s)';
-            subplot(4,1,4)
-            imagesc(ispike)
-            caxis([0 2]);colormap(gca,[rgb('white'); rgb('black')])
-            ylabel('Bin #')
-            c = colorbar;c.Ticks = [0.5 1.5];
-            c.TickLabels = {'Good','Spike'};
-            xlabel('Ping #')
-            drawnow
-            if opt.saveplots
-                figname = [savedir SNprocess slash get(gcf,'Name')];
-                print(figname,'-dpng')
-                close gcf
-            end
-        end
-
-        %%%%%% Dissipation Estimates %%%%%%
-
-        % Sampling rate and window size
-        fs = 1/dt; nwin = 64;
-        if nwin > nping
-            nwin = nping;
-        end
-
-        % Skip dissipation estimates if bad-burst
-        if badburst  ||  sum(badping)/nping > 0.90
-            disp('   Skipping dissipation...')
-            wpeof = NaN(size(hrw));
-            eps_struct0 = NaN(size(hrw));
-            eps_structHP = NaN(size(hrw));
-            eps_structEOF = NaN(size(hrw));
-            qual0.mspe = NaN(size(hrw));
-            qual0.slope = NaN(size(hrw));
-            qual0.epserr = NaN(size(hrw));
-            qual0.A = NaN(size(hrw));
-            qual0.B = NaN(size(hrw));
-            qual0.N = NaN(size(hrw));
-            qualHP.mspe = NaN(size(hrw));
-            qualHP.slope = NaN(size(hrw));
-            qualHP.epserr = NaN(size(hrw));
-            qualHP.A = NaN(size(hrw));
-            qualHP.B = NaN(size(hrw));
-            qualHP.N = NaN(size(hrw));
-            qualEOF.mspe = NaN(size(hrw));
-            qualEOF.slope = NaN(size(hrw));
-            qualEOF.epserr = NaN(size(hrw));
-            qualEOF.A = NaN(size(hrw));
-            qualEOF.B = NaN(size(hrw));
-            qualEOF.N = NaN(size(hrw));
-            wpsd = NaN(nbin,2*nwin+1);
-            bobpsd = NaN(1,2*nwin+1);
-            f = NaN(1,2*nwin+1);
-        else
-
-            %EOF High-pass
-            eof_amp = NaN(nping,nbin);
-            [eofs,eof_amp(~badping,:),~,~] = eof(wclean(:,~badping)');
-            for ieof = 1:nbin
-                eof_amp(:,ieof) = interp1(find(~badping),eof_amp(~badping,ieof),1:nping);
-            end
-            wpeof = eofs(:,opt.nsumeof+1:end)*(eof_amp(:,opt.nsumeof+1:end)');
-
-            %Structure Function Dissipation
-            rmin = dz;
-            rmax = 4*dz;
-            nzfit = 1;
-            w = wclean;
-            wp1 = wpeof;
-            wp2 = wphp;
-            ibad = repmat(badping,nbin,1) | ispike;
-            w(ibad) = NaN;
-            wp1(ibad) = NaN;
-            wp2(ibad) = NaN;
-            warning('off','all')
-            [eps_struct0,qual0] = SFdissipation(w,hrz,rmin,2*rmax,nzfit,'cubic','mean');
-            [eps_structEOF,qualEOF] = SFdissipation(wp1,hrz,rmin,rmax,nzfit,'linear','mean');
-            [eps_structHP,qualHP] = SFdissipation(wp2,hrz,rmin,rmax,nzfit,'linear','mean');
-            warning('on','all')
-
-            % Motion spectra (bobbing)
-            [bobpsd,f] = pwelch(detrend(gradient(burst.Pressure,dt)),nwin,[],[],fs);
-            wpsd = NaN(nbin,nwin*2+1);
-            for ibin = 1:nbin
-                iw = w(ibin,:);
-                iNaN = isnan(iw);
-                if sum(iNaN) > 0.9*nping % skip if more than 90% NaN
-                    continue
-                else
-                    iw(iNaN) = mean(iw,'omitnan'); % Replace NaN w/mean
-                    [wpsd(ibin,:),f] = pwelch(detrend(iw),nwin,[],[],fs);
-                end
-            end
-
-            if opt.plotburst
-                clear b s
-                figure('color','w','Name',[bname '_wspectra_eps'])
-                MP = get(0,'monitorposition');
-                set(gcf,'outerposition',MP(1,:).*[1 1 1 1]);
-                subplot(1,4,[1 2])
-                cmap = colormap;
-                for ibin = 1:nbin
-                    cind = round(size(cmap,1)*ibin/nbin);
-                    l1 = loglog(f,wpsd(ibin,:),'color',cmap(cind,:),'LineWidth',1.5);
-                    hold on
-                end
-                l2 = loglog(f,bobpsd,'LineWidth',2,'color',rgb('grey'));
-                xlabel('Frequency [Hz]')
-                ylabel('TKE [m^2/s^2/Hz]')
-                title('HR Spectra')
-                c = colorbar;
-                c.Label.String = 'Bin #';
-                c.TickLabels = num2str(round(c.Ticks'.*nbin));
-                legend([l1 l2],'S_{w}','S_{bob}','Location','northwest')
-                ylim(10.^[-6 0.8])
-                xlim([10^-0.5 max(f)])
-                subplot(1,4,3)
-                b(1) = errorbar(hrw,hrz,sqrt(hrwvar)./nping,'horizontal');
-                hold on
-                b(2) = errorbar(avgw,avgz,sqrt(avgwvar)./nping,'horizontal');
-                set(b,'LineWidth',2)
-                plot([0 0],[0 20],'k--')
-                xlabel('w [m/s]');
-                title('Velocity')
-                set(gca,'Ydir','reverse')
-                legend(b,'HR','Broadband','Location','southeast')
-                ylim([0 6])
-                xlim([-0.075 0.075])
-                set(gca,'YAxisLocation','right')
-                subplot(1,4,4)
-                s(1) = semilogx(eps_structEOF,hrz,'r','LineWidth',2);
-                hold on
-                s(2) =  semilogx(eps_structHP,hrz,':r','LineWidth',2);
-                s(3) = semilogx(eps_struct0,hrz,'color',rgb('grey'),'LineWidth',2);
-                xlim(10.^([-9 -3]))
-                ylim([0 6])
-                legend(s,'SF','SF (high-pass)','SF (modified)','Location','southeast')
-                title('Dissipation')
-                xlabel('\epsilon [W/Kg]'),ylabel('z [m]')
-                set(gca,'Ydir','reverse')
-                set(gca,'YAxisLocation','right')
-                drawnow
-                if opt.saveplots
-                    figname = [savedir SNprocess slash get(gcf,'Name')];
-                    print(figname,'-dpng')
-                    close gcf
-                end
-            end
-        end
-    end
-
-    %%%%%%%% Save processed signature data in seperate structure %%%%%%%%
+        [HRprofile,fh] = processSIGburst(burst,opt);
+    
+           if opt.saveplots && ~isempty(fh)
+            figure(fh(1))
+            set(gcf,'Name',[bname '_HR_data'])
+            figname = [savedir SNprocess slash get(gcf,'Name')];
+            print(figname,'-dpng')
+            close gcf
+            
+            figure(fh(2))
+            set(gcf,'Name',[bname '_HR_profiles'])
+            figname = [savedir SNprocess slash get(gcf,'Name')];
+            print(figname,'-dpng')
+            close gcf
+           end
+    
+    %%%%%%%% Save detailed signature data in SIG structure %%%%%%%%
 
     %Time
     SIG(isig).time = t0;
+    % HR data
+    SIG(isig).HRprofile = HRprofile;
     %Temperaure
     SIG(isig).watertemp = profile.temp;
-    % HR data
-    SIG(isig).HRprofile.w = hrw;
-    SIG(isig).HRprofile.wvar = hrwvar;
-    SIG(isig).HRprofile.z = hrz';
-    SIG(isig).HRprofile.eps_struct0 = eps_struct0';
-    SIG(isig).HRprofile.eps_structHP = eps_structHP';
-    SIG(isig).HRprofile.eps_structEOF = eps_structEOF';
-    SIG(isig).HRprofile.QC.wmag = mean(abs(wclean),2,'omitnan');
-    SIG(isig).HRprofile.QC.wmag0 = mean(abs(hrvel),2,'omitnan');
-    SIG(isig).HRprofile.QC.w0 = mean(hrvel,2,'omitnan');
-    SIG(isig).HRprofile.QC.wvar0 = var(hrvel,[],2,'omitnan');
-    SIG(isig).HRprofile.QC.wpvar = var(wpeof,[],2,'omitnan');
-    SIG(isig).HRprofile.QC.hrcorr = mean(hrcorr,2,'omitnan')';
-    SIG(isig).HRprofile.QC.hramp = mean(hramp,2,'omitnan')';
-    SIG(isig).HRprofile.QC.hrampvar = var(hramp,[],2,'omitnan');
-    SIG(isig).HRprofile.QC.hrcorrvar = var(hrcorr,[],2,'omitnan');
-    SIG(isig).HRprofile.QC.mspe0 = qual0.mspe;
-    SIG(isig).HRprofile.QC.mspeHP = qualHP.mspe;
-    SIG(isig).HRprofile.QC.mspeEOF = qualEOF.mspe;
-    SIG(isig).HRprofile.QC.slope0 = qual0.slope;
-    SIG(isig).HRprofile.QC.slopeHP = qualHP.slope;
-    SIG(isig).HRprofile.QC.slopeEOF = qualEOF.slope;
-    SIG(isig).HRprofile.QC.epserr0 = qual0.epserr;
-    SIG(isig).HRprofile.QC.epserrHP = qualHP.epserr;
-    SIG(isig).HRprofile.QC.epserrEOF = qualEOF.epserr;       
-    SIG(isig).HRprofile.QC.N0 = qual0.N;
-    SIG(isig).HRprofile.QC.NHP = qualHP.N;
-    SIG(isig).HRprofile.QC.NEOF = qualEOF.N;    
-    SIG(isig).HRprofile.QC.pspike = sum(ispike,2,'omitnan')./nping;
     % Broadband data
-    SIG(isig).profile.u = profile.avgu;
-    SIG(isig).profile.v = profile.avgv;
-    SIG(isig).profile.w = profile.avgw;
-    SIG(isig).profile.uvar = profile.avguvar;
-    SIG(isig).profile.vvar = profile.avgvvar;
-    SIG(isig).profile.wvar = profile.avgwvar;
-    SIG(isig).profile.z = profile.avgz;
-    SIG(isig).profile.QC.ucorr = profile.ucorr;
-    SIG(isig).profile.QC.wcorr = profile.vcorr;
-    SIG(isig).profile.QC.vcorr = profile.wcorr;
-    SIG(isig).profile.QC.uamp = profile.uamp;
-    SIG(isig).profile.QC.vamp = profile.vamp;
-    SIG(isig).profile.QC.wamp = profile.wamp;
+    SIG(isig).profile = profile;
     % Motion
     SIG(isig).motion.pitch = mean(avg.Pitch,'omitnan');
     SIG(isig).motion.roll = mean(avg.Roll,'omitnan');
@@ -570,10 +335,6 @@ for iburst = 1:nburst
     SIG(isig).motion.pitchvar = var(avg.Pitch,'omitnan');
     SIG(isig).motion.rollvar = var(avg.Roll,'omitnan');
     SIG(isig).motion.headvar = var(unwrap(avg.Heading),'omitnan');
-    SIG(isig).motion.waveheight = NaN;% Will fill in later from SWIFT if avail
-    SIG(isig).motion.wpsd = wpsd;
-    SIG(isig).motion.bobpsd = bobpsd;
-    SIG(isig).motion.f = f;
     % Badburst & flags
     SIG(isig).badburst = badburst;
     SIG(isig).flag.altimeter = maxz;
@@ -604,43 +365,40 @@ for iburst = 1:nburst
         if  timematch && ~badburst % Good burst & time match
             % HR data
             SWIFT(tindex).signature.HRprofile = [];
-            SWIFT(tindex).signature.HRprofile.w = hrw;
-            SWIFT(tindex).signature.HRprofile.wvar = hrwvar;
-            SWIFT(tindex).signature.HRprofile.z = hrz';
-            SWIFT(tindex).signature.HRprofile.tkedissipationrate = eps_structEOF';
+            SWIFT(tindex).signature.HRprofile.w = HRprofile.w;
+            SWIFT(tindex).signature.HRprofile.wvar = HRprofile.wvar;
+            SWIFT(tindex).signature.HRprofile.z = HRprofile.z';
+            SWIFT(tindex).signature.HRprofile.tkedissipationrate = HRprofile.eps_structEOF;
             % Broadband data
             SWIFT(tindex).signature.profile = [];
-            SWIFT(tindex).signature.profile.east = profile.avgu;
-            SWIFT(tindex).signature.profile.north = profile.avgv;
-            SWIFT(tindex).signature.profile.w = profile.avgw;
-            SWIFT(tindex).signature.profile.uvar = profile.avguvar;
-            SWIFT(tindex).signature.profile.vvar = profile.avgvvar;
-            SWIFT(tindex).signature.profile.wvar = profile.avgwvar;
-            SWIFT(tindex).signature.profile.z = profile.avgz;
+            SWIFT(tindex).signature.profile.east = profile.u;
+            SWIFT(tindex).signature.profile.north = profile.v;
+            SWIFT(tindex).signature.profile.w = profile.w;
+            SWIFT(tindex).signature.profile.uvar = profile.uvar;
+            SWIFT(tindex).signature.profile.vvar = profile.vvar;
+            SWIFT(tindex).signature.profile.wvar = profile.wvar;
+            SWIFT(tindex).signature.profile.z = profile.z;
             % Altimeter & Out-of-Water Flag
             SWIFT(tindex).signature.altimeter = maxz;
             % Temperaure
             SWIFT(tindex).watertemp = profile.temp;
-            
-            % Save significant wave height in SIG structure if avail
-            SIG(isig-1).motion.waveheight = SWIFT(tindex).sigwaveheight;
 
         elseif timematch && badburst % Bad burst & time match
             % HR data
             SWIFT(tindex).signature.HRprofile = [];
-            SWIFT(tindex).signature.HRprofile.w = NaN(size(hrw));
-            SWIFT(tindex).signature.HRprofile.wvar = NaN(size(hrw));
-            SWIFT(tindex).signature.HRprofile.z = hrz;
-            SWIFT(tindex).signature.HRprofile.tkedissipationrate = NaN(size(eps_structEOF'));
+            SWIFT(tindex).signature.HRprofile.w = NaN(size(HRprofile.w));
+            SWIFT(tindex).signature.HRprofile.wvar = NaN(size(HRprofile.w));
+            SWIFT(tindex).signature.HRprofile.z = HRprofile.z';
+            SWIFT(tindex).signature.HRprofile.tkedissipationrate = NaN(size(HRprofile.w'));
             % Broadband data
             SWIFT(tindex).signature.profile = [];
-            SWIFT(tindex).signature.profile.w = NaN(size(profile.avgu));
-            SWIFT(tindex).signature.profile.east = NaN(size(profile.avgu));
-            SWIFT(tindex).signature.profile.north = NaN(size(profile.avgu));
-            SWIFT(tindex).signature.profile.uvar = NaN(size(profile.avgu));
-            SWIFT(tindex).signature.profile.vvar = NaN(size(profile.avgu));
-            SWIFT(tindex).signature.profile.wvar = NaN(size(profile.avgu));
-            SWIFT(tindex).signature.profile.z = profile.avgz;
+            SWIFT(tindex).signature.profile.w = NaN(size(profile.u));
+            SWIFT(tindex).signature.profile.east = NaN(size(profile.u));
+            SWIFT(tindex).signature.profile.north = NaN(size(profile.u));
+            SWIFT(tindex).signature.profile.uvar = NaN(size(profile.u));
+            SWIFT(tindex).signature.profile.vvar = NaN(size(profile.u));
+            SWIFT(tindex).signature.profile.wvar = NaN(size(profile.u));
+            SWIFT(tindex).signature.profile.z = profile.z;
         elseif ~timematch && ~badburst % Good burst, no time match
             disp('   ALERT: Burst good, but no time match...')
             tindex = length(SWIFT)+1;
@@ -660,19 +418,19 @@ for iburst = 1:nburst
             end
             % HR data
             SWIFT(tindex).signature.HRprofile = [];
-            SWIFT(tindex).signature.HRprofile.w = hrw;
-            SWIFT(tindex).signature.HRprofile.wvar = hrwvar;
-            SWIFT(tindex).signature.HRprofile.z = hrz;
-            SWIFT(tindex).signature.HRprofile.tkedissipationrate = eps_structEOF';
+            SWIFT(tindex).signature.HRprofile.w = HRprofile.w;
+            SWIFT(tindex).signature.HRprofile.wvar = HRprofile.wvar;
+            SWIFT(tindex).signature.HRprofile.z = HRprofile.z';
+            SWIFT(tindex).signature.HRprofile.tkedissipationrate = HRprofile.eps_structEOF;
             % Broadband data
             SWIFT(tindex).signature.profile = [];
-            SWIFT(tindex).signature.profile.east = profile.avgu;
-            SWIFT(tindex).signature.profile.north = profile.avgv;
-            SWIFT(tindex).signature.profile.w = profile.avgw;
-            SWIFT(tindex).signature.profile.uvar = profile.avguvar;
-            SWIFT(tindex).signature.profile.vvar = profile.avgvvar;
-            SWIFT(tindex).signature.profile.wvar = profile.avgwvar;
-            SWIFT(tindex).signature.profile.z = profile.avgz;
+            SWIFT(tindex).signature.profile.east = profile.u;
+            SWIFT(tindex).signature.profile.north = profile.v;
+            SWIFT(tindex).signature.profile.w = profile.w;
+            SWIFT(tindex).signature.profile.uvar = profile.uvar;
+            SWIFT(tindex).signature.profile.vvar = profile.vvar;
+            SWIFT(tindex).signature.profile.wvar = profile.wvar;
+            SWIFT(tindex).signature.profile.z = profile.z;
             % Altimeter
             SWIFT(tindex).signature.altimeter = maxz;
             % Temperaure
@@ -696,19 +454,19 @@ if ~isempty(fieldnames(SWIFT))
         for it = inan'
             % HR data
             SWIFT(it).signature.HRprofile = [];
-            SWIFT(it).signature.HRprofile.w = NaN(size(hrw));
-            SWIFT(it).signature.HRprofile.wvar = NaN(size(hrw));
-            SWIFT(it).signature.HRprofile.z = hrz;
-            SWIFT(it).signature.HRprofile.tkedissipationrate = NaN(size(eps_structEOF'));
+            SWIFT(it).signature.HRprofile.w = NaN(size(HRprofile.w));
+            SWIFT(it).signature.HRprofile.wvar = NaN(size(HRprofile.w));
+            SWIFT(it).signature.HRprofile.z = HRprofile.z;
+            SWIFT(it).signature.HRprofile.tkedissipationrate = NaN(size(HRprofile.w'));
             % Broadband data
             SWIFT(it).signature.profile = [];
-            SWIFT(it).signature.profile.w = NaN(size(profile.avgu));
-            SWIFT(it).signature.profile.east = NaN(size(profile.avgu));
-            SWIFT(it).signature.profile.north = NaN(size(profile.avgu));
-            SWIFT(it).signature.profile.uvar = NaN(size(profile.avgu));
-            SWIFT(it).signature.profile.vvar = NaN(size(profile.avgu));
-            SWIFT(it).signature.profile.wvar = NaN(size(profile.avgu));
-            SWIFT(it).signature.profile.z = profile.avgz;
+            SWIFT(it).signature.profile.w = NaN(size(profile.u));
+            SWIFT(it).signature.profile.east = NaN(size(profile.u));
+            SWIFT(it).signature.profile.north = NaN(size(profile.u));
+            SWIFT(it).signature.profile.uvar = NaN(size(profile.u));
+            SWIFT(it).signature.profile.vvar = NaN(size(profile.u));
+            SWIFT(it).signature.profile.wvar = NaN(size(profile.u));
+            SWIFT(it).signature.profile.z = profile.z;
         end
     end
 end
@@ -735,7 +493,7 @@ end
 
 %%%%%% Plot burst Averaged SWIFT Signature Data %%%%%%
 if opt.plotmission
-    catSIG(SIG,'plot','qc');
+    catSIG(SIG,'plot');
     set(gcf,'Name',SNprocess)
     if opt.saveplots
         figname = [savedir get(gcf,'Name')];

--- a/Signature/reprocess_SIG.m
+++ b/Signature/reprocess_SIG.m
@@ -307,6 +307,10 @@ for iburst = 1:nburst
     %%%%%%% Process HR velocity data ('burst' structure) %%%%%%
     
         [HRprofile,fh] = processSIGburst(burst,opt);
+        
+        if isempty(HRprofile)
+            HRprofile = NaNstructR(SIG(isig-1).HRprofile);
+        end
     
            if opt.saveplots && ~isempty(fh)
             figure(fh(1))
@@ -409,19 +413,8 @@ for iburst = 1:nburst
             disp('   ALERT: Burst good, but no time match...')
             tindex = length(SWIFT)+1;
             burstreplaced = [burstreplaced; true]; %#ok<AGROW>
-            varcopy = fieldnames(SWIFT);
-            varcopy = varcopy(~strcmp(varcopy,'signature'));
-            for icopy = 1:length(varcopy)
-                if isa(SWIFT(1).(varcopy{icopy}),'double')
-                    SWIFT(tindex).(varcopy{icopy}) = NaN;
-                elseif isa(SWIFT(1).(varcopy{icopy}),'struct')
-                    varcopy2 = fieldnames(SWIFT(1).(varcopy{icopy}));
-                    for icopy2 = 1:length(varcopy2)
-                        varsize = size(SWIFT(1).(varcopy{icopy}).(varcopy2{icopy2}));
-                        SWIFT(tindex).(varcopy{icopy}).(varcopy2{icopy2}) = NaN(varsize);
-                    end
-                end
-            end
+            % Copy fields from SWIFT(1);
+            SWIFT(tindex) = NaNstructR(SWIFT(1));            
             % HR data
             SWIFT(tindex).signature.HRprofile = [];
             SWIFT(tindex).signature.HRprofile.w = HRprofile.w;
@@ -444,7 +437,7 @@ for iburst = 1:nburst
             SWIFT(tindex).watertemp = profile.temp;
             % Time
             SWIFT(tindex).time = btime;
-            disp(['   Burst time: ' datestr(btime)])
+            SWIFT(tindex).date = datestr(btime,'ddmmyyyy');
             disp(['   (new) SWIFT time: ' datestr(SWIFT(tindex).time)])
         end
     end

--- a/Signature/reprocess_SIG.m
+++ b/Signature/reprocess_SIG.m
@@ -185,16 +185,20 @@ if isempty(bfiles)
     error('   No burst files found    ')
 end
 bfiles = bfiles(~contains({bfiles.name},'smoothwHR'));
-ipart = find(contains({bfiles.name},'partial'));
-idel = false(size(ipart));
-for ip = 1:length(ipart)
-    pname = bfiles(ipart(ip)).name;
-    pdir = bfiles(ipart(ip)).folder;
-    if exist([pdir slash pname(1:end-12) '.mat'])
-        idel(ip) = true;
-    end
-end
-bfiles(ipart(idel)-1) = [];
+
+% Deal with 'partial' files (two options)
+bfiles = bfiles(~contains({bfiles.name},'partial'));
+% % Only delete partial files if the full file exists (WHY!?)
+% ipart = find(contains({bfiles.name},'partial'));
+% idel = false(size(ipart));
+% for ip = 1:length(ipart)
+%     pname = bfiles(ipart(ip)).name;
+%     pdir = bfiles(ipart(ip)).folder;
+%     if exist([pdir slash pname(1:end-12) '.mat'])
+%         idel(ip) = true;
+%     end
+% end
+% bfiles(ipart(idel)-1) = [];
 nburst = length(bfiles);
 
 %% Loop through and process burst files

--- a/Signature/reprocess_SIG.m
+++ b/Signature/reprocess_SIG.m
@@ -211,9 +211,9 @@ for iburst = 1:nburst
 
     % Load burst file
     if opt.readraw
-       [burst,avg,battery,echo] = readSWIFTv4_SIG([bfiles(iburst).folder slash bfiles(iburst).name]);
+   [burst,avg,~,~] = readSWIFTv4_SIG([bfiles(iburst).folder slash bfiles(iburst).name]);
     else
-        load([bfiles(iburst).folder slash bfiles(iburst).name])
+        load([bfiles(iburst).folder slash bfiles(iburst).name],'burst','avg')
     end
     
     % Skip burst if empty
@@ -368,7 +368,8 @@ for iburst = 1:nburst
             SWIFT(tindex).signature.HRprofile.w = HRprofile.w;
             SWIFT(tindex).signature.HRprofile.wvar = HRprofile.wvar;
             SWIFT(tindex).signature.HRprofile.z = HRprofile.z';
-            SWIFT(tindex).signature.HRprofile.tkedissipationrate = HRprofile.eps_structEOF;
+            SWIFT(tindex).signature.HRprofile.tkedissipationrate = ...
+                HRprofile.eps_structEOF;
             % Broadband data
             SWIFT(tindex).signature.profile = [];
             SWIFT(tindex).signature.profile.east = profile.u;
@@ -389,7 +390,8 @@ for iburst = 1:nburst
             SWIFT(tindex).signature.HRprofile.w = NaN(size(HRprofile.w));
             SWIFT(tindex).signature.HRprofile.wvar = NaN(size(HRprofile.w));
             SWIFT(tindex).signature.HRprofile.z = HRprofile.z';
-            SWIFT(tindex).signature.HRprofile.tkedissipationrate = NaN(size(HRprofile.w'));
+            SWIFT(tindex).signature.HRprofile.tkedissipationrate = ...
+                NaN(size(HRprofile.w'));
             % Broadband data
             SWIFT(tindex).signature.profile = [];
             SWIFT(tindex).signature.profile.w = NaN(size(profile.u));
@@ -402,7 +404,7 @@ for iburst = 1:nburst
         elseif ~timematch && ~badburst % Good burst, no time match
             disp('   ALERT: Burst good, but no time match...')
             tindex = length(SWIFT)+1;
-            burstreplaced = [burstreplaced; true];
+            burstreplaced = [burstreplaced; true]; %#ok<AGROW>
             varcopy = fieldnames(SWIFT);
             varcopy = varcopy(~strcmp(varcopy,'signature'));
             for icopy = 1:length(varcopy)
@@ -421,7 +423,8 @@ for iburst = 1:nburst
             SWIFT(tindex).signature.HRprofile.w = HRprofile.w;
             SWIFT(tindex).signature.HRprofile.wvar = HRprofile.wvar;
             SWIFT(tindex).signature.HRprofile.z = HRprofile.z';
-            SWIFT(tindex).signature.HRprofile.tkedissipationrate = HRprofile.eps_structEOF;
+            SWIFT(tindex).signature.HRprofile.tkedissipationrate = ...
+                HRprofile.eps_structEOF;
             % Broadband data
             SWIFT(tindex).signature.profile = [];
             SWIFT(tindex).signature.profile.east = profile.u;


### PR DESCRIPTION
Updates to how reprocess_SIG QCs. Previously was using along-beam HR velocity variance as a flag for bad pings, but this prevented dissipation estimates under storm conditions. Loosened the criteria for computing dissipation rate. Prefer to compute dissipation and then use QC flags saved in SIG structure to evaluate quality after the fact. Also added NaNstruct and NaNstructR which NaNs out an entire structure to help with missing timesteps/data.