### PR TITLE
Fix missing signature

### DIFF
--- a/GeneralTools/SWIFT2NC.m
+++ b/GeneralTools/SWIFT2NC.m
@@ -78,9 +78,6 @@ if isfield(SWIFT,'downlooking')
 end
 if isfield(SWIFT,'signature')  
     sig_names = fieldnames(SWIFT(1).signature);
-    disp(~isempty(SWIFT(1).signature.HRprofile.z))
-    disp(SWIFT(1).signature.HRprofile.z)
-
     if isfield(SWIFT(1).signature,'HRprofile')
         if ~isempty(SWIFT(1).signature.HRprofile.z)
             zHR_dim = netcdf.defDim(ncid,'zHR', length(SWIFT(1).signature.HRprofile.z));


### PR DESCRIPTION
Try this on your file or link me to test. This is what my sig structure looked like. We could also prune the signature from the MATLAB struct if missing data elsewhere, but this is where the error was for me so my first guess for a fix

<img width="278" alt="image" src="https://github.com/user-attachments/assets/d4b18e70-f485-4f77-8486-c07dcfd6094a" />
<img width="269" alt="image" src="https://github.com/user-attachments/assets/6de3cd7a-7c40-46b4-90a8-644dee03f474" />
